### PR TITLE
FP-12937: GCS CustomTime Attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.2.0
 	github.com/grandcat/zeroconf v1.0.0
+	github.com/h2non/gock v1.2.0
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/jlaffaye/ftp v0.0.0-20201112195030-9aae4d151126
 	github.com/lestrrat-go/jwx v1.1.6
@@ -74,6 +75,7 @@ require (
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,10 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/h2non/gock v1.2.0 h1:K6ol8rfrRkUOefooBC8elXoaNGYkpp7y2qcxGG6BzUE=
+github.com/h2non/gock v1.2.0/go.mod h1:tNhoxHYW2W42cYkYb1WqzdbYIieALC99kpYr7rH/BQk=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.8.1/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
@@ -638,6 +642,8 @@ github.com/nats-io/nats.go v1.11.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/
 github.com/nats-io/nkeys v0.2.0/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/sftpd/sftpd_test.go
+++ b/sftpd/sftpd_test.go
@@ -7043,16 +7043,23 @@ func TestSSHCopyQuotaLimits(t *testing.T) {
 		// now decrease the limits
 		user.QuotaFiles = 1
 		user.QuotaSize = testFileSize * 10
-		user.VirtualFolders[1].QuotaSize = testFileSize
-		user.VirtualFolders[1].QuotaFiles = 10
+		for idx, f := range user.VirtualFolders {
+			if f.Name == folderName2 {
+				user.VirtualFolders[idx].QuotaSize = testFileSize
+				user.VirtualFolders[idx].QuotaFiles = 10
+			}
+		}
 		user, _, err = httpdtest.UpdateUser(user, http.StatusOK, "")
 		assert.NoError(t, err)
 		assert.Equal(t, 1, user.QuotaFiles)
 		assert.Equal(t, testFileSize*10, user.QuotaSize)
 		if assert.Len(t, user.VirtualFolders, 2) {
-			f := user.VirtualFolders[1]
-			assert.Equal(t, testFileSize, f.QuotaSize)
-			assert.Equal(t, 10, f.QuotaFiles)
+			for _, f := range user.VirtualFolders {
+				if f.Name == folderName2 {
+					assert.Equal(t, testFileSize, f.QuotaSize)
+					assert.Equal(t, 10, f.QuotaFiles)
+				}
+			}
 		}
 		_, err = runSSHCommand(fmt.Sprintf("sftpgo-copy %v %v", path.Join(vdirPath1, testDir),
 			path.Join(vdirPath2, testDir+".copy")), user, usePubKey)

--- a/vfs/gcsfs_test.go
+++ b/vfs/gcsfs_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	testBaseUrl = `http://localhost/gcs-test`
+	testBaseURL = `http://localhost/gcs-test`
 )
 
 var (
@@ -35,7 +35,7 @@ func (Suite *GCSFsSuite) SetupSuite() {
 	gcsClient, err := storage.NewClient(
 		context.Background(),
 		option.WithHTTPClient(&http.Client{}),
-		option.WithEndpoint(testBaseUrl),
+		option.WithEndpoint(testBaseURL),
 	)
 	if err != nil {
 		Suite.FailNowf(`storage.NewClient`, `failed to setup storage client: %s`, err)
@@ -56,7 +56,7 @@ func (Suite *GCSFsSuite) SetupSuite() {
 func (Suite *GCSFsSuite) TestStat_NoCustomTime() {
 	defer gock.Off()
 
-	gock.New(testBaseUrl).
+	gock.New(testBaseURL).
 		Get("/b/bucket1/o/users/test1/test.txt").
 		Reply(200).
 		JSON(map[string]any{
@@ -81,7 +81,7 @@ func (Suite *GCSFsSuite) TestStat_NoCustomTime() {
 func (Suite *GCSFsSuite) TestStat_ZeroCustomTime() {
 	defer gock.Off()
 
-	gock.New(testBaseUrl).
+	gock.New(testBaseURL).
 		Get("/b/bucket1/o/users/test1/test.txt").
 		Reply(200).
 		JSON(map[string]any{
@@ -106,7 +106,7 @@ func (Suite *GCSFsSuite) TestStat_ZeroCustomTime() {
 func (Suite *GCSFsSuite) TestStat_ValidCustomTime() {
 	defer gock.Off()
 
-	gock.New(testBaseUrl).
+	gock.New(testBaseURL).
 		Get("/b/bucket1/o/users/test1/test.txt").
 		Reply(200).
 		JSON(map[string]any{
@@ -131,7 +131,7 @@ func (Suite *GCSFsSuite) TestStat_ValidCustomTime() {
 func (Suite *GCSFsSuite) TestReadDir_IsObject_NoCustomTime() {
 	defer gock.Off()
 
-	gock.New(testBaseUrl).
+	gock.New(testBaseURL).
 		Get("/b/bucket1/o/users/test1/test.txt").
 		Reply(200).
 		JSON(map[string]any{
@@ -158,7 +158,7 @@ func (Suite *GCSFsSuite) TestReadDir_IsObject_NoCustomTime() {
 func (Suite *GCSFsSuite) TestReadDir_IsObject_WithCustomTime() {
 	defer gock.Off()
 
-	gock.New(testBaseUrl).
+	gock.New(testBaseURL).
 		Get("/b/bucket1/o/users/test1/test.txt").
 		Reply(200).
 		JSON(map[string]any{
@@ -185,7 +185,7 @@ func (Suite *GCSFsSuite) TestReadDir_IsObject_WithCustomTime() {
 func (Suite *GCSFsSuite) TestReadDir_IsDir() {
 	defer gock.Off()
 
-	gock.New(testBaseUrl).
+	gock.New(testBaseURL).
 		Get("/b/bucket1/o").
 		AddMatcher(customTimeInFieldsList()).
 		Reply(200).
@@ -234,7 +234,7 @@ func (Suite *GCSFsSuite) TestCreate_CustomTimeAttribute() {
 	Suite.Fs._customTimeOverride = &jan1
 	defer func() { Suite.Fs._customTimeOverride = nil }()
 
-	gock.New(testBaseUrl).
+	gock.New(testBaseURL).
 		Post("/upload/storage/v1/b/bucket1/o").
 		AddMatcher(customTimeInUploadRequest(jan1)).
 		Reply(200)

--- a/vfs/gcsfs_test.go
+++ b/vfs/gcsfs_test.go
@@ -229,10 +229,11 @@ func (Suite *GCSFsSuite) TestReadDir_IsDir() {
 }
 
 func (Suite *GCSFsSuite) TestCreate_CustomTimeAttribute() {
-	defer gock.Off()
-
-	Suite.Fs._customTimeOverride = &jan1
-	defer func() { Suite.Fs._customTimeOverride = nil }()
+	Suite.Fs.nowFunc = func() time.Time { return jan1 }
+	defer func() {
+		gock.Off()
+		Suite.Fs.nowFunc = time.Now
+	}()
 
 	gock.New(testBaseURL).
 		Post("/upload/storage/v1/b/bucket1/o").

--- a/vfs/gcsfs_test.go
+++ b/vfs/gcsfs_test.go
@@ -1,0 +1,291 @@
+package vfs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/option"
+)
+
+const (
+	testBaseUrl = `http://localhost/gcs-test`
+)
+
+var (
+	apr28 = time.Date(2025, 04, 28, 15, 04, 05, 00, time.UTC)
+	jan1  = time.Date(2025, 01, 01, 12, 00, 00, 00, time.UTC)
+)
+
+type GCSFsSuite struct {
+	suite.Suite
+	Fs *GCSFs
+}
+
+func (Suite *GCSFsSuite) SetupSuite() {
+	gcsClient, err := storage.NewClient(
+		context.Background(),
+		option.WithHTTPClient(&http.Client{}),
+		option.WithEndpoint(testBaseUrl),
+	)
+	if err != nil {
+		Suite.FailNowf(`storage.NewClient`, `failed to setup storage client: %s`, err)
+	}
+
+	Suite.Fs = &GCSFs{
+		svc: gcsClient,
+		config: &GCSFsConfig{
+			KeyPrefix: `users/test1/`,
+			Bucket:    `bucket1`,
+		},
+		localTempDir:   os.TempDir(),
+		ctxTimeout:     30 * time.Second,
+		ctxLongTimeout: 300 * time.Second,
+	}
+}
+
+func (Suite *GCSFsSuite) TestStat_NoCustomTime() {
+	defer gock.Off()
+
+	gock.New(testBaseUrl).
+		Get("/b/bucket1/o/users/test1/test.txt").
+		Reply(200).
+		JSON(map[string]any{
+			"bucket":      "bucket1",
+			"name":        "test.txt",
+			"contentType": "text/plain",
+			"size":        "8",
+			"updated":     apr28.Format(time.RFC3339),
+			//"customTime":  "",
+		})
+
+	info, err := Suite.Fs.Stat("users/test1/test.txt")
+	Suite.NoError(err)
+	Suite.Equal("test.txt", info.Name())
+	Suite.Equal(int64(8), info.Size())
+	Suite.Equal(apr28, info.ModTime())
+	Suite.False(info.IsDir())
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
+}
+
+func (Suite *GCSFsSuite) TestStat_ZeroCustomTime() {
+	defer gock.Off()
+
+	gock.New(testBaseUrl).
+		Get("/b/bucket1/o/users/test1/test.txt").
+		Reply(200).
+		JSON(map[string]any{
+			"bucket":      "bucket1",
+			"name":        "test.txt",
+			"contentType": "text/plain",
+			"size":        "8",
+			"updated":     apr28.Format(time.RFC3339),
+			"customTime":  "0001-01-01T00:00:00Z",
+		})
+
+	info, err := Suite.Fs.Stat("users/test1/test.txt")
+	Suite.NoError(err)
+	Suite.Equal("test.txt", info.Name())
+	Suite.Equal(int64(8), info.Size())
+	Suite.Equal(apr28, info.ModTime())
+	Suite.False(info.IsDir())
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
+}
+
+func (Suite *GCSFsSuite) TestStat_ValidCustomTime() {
+	defer gock.Off()
+
+	gock.New(testBaseUrl).
+		Get("/b/bucket1/o/users/test1/test.txt").
+		Reply(200).
+		JSON(map[string]any{
+			"bucket":      "bucket1",
+			"name":        "test.txt",
+			"contentType": "text/plain",
+			"size":        "8",
+			"updated":     apr28.Format(time.RFC3339),
+			"customTime":  jan1.Format(time.RFC3339),
+		})
+
+	info, err := Suite.Fs.Stat("users/test1/test.txt")
+	Suite.NoError(err)
+	Suite.Equal("test.txt", info.Name())
+	Suite.Equal(int64(8), info.Size())
+	Suite.Equal(jan1, info.ModTime())
+	Suite.False(info.IsDir())
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
+}
+
+func (Suite *GCSFsSuite) TestReadDir_IsObject_NoCustomTime() {
+	defer gock.Off()
+
+	gock.New(testBaseUrl).
+		Get("/b/bucket1/o/users/test1/test.txt").
+		Reply(200).
+		JSON(map[string]any{
+			"bucket":      "bucket1",
+			"name":        "test.txt",
+			"contentType": "text/plain",
+			"size":        "8",
+			"updated":     apr28.Format(time.RFC3339),
+			//"customTime":  "",
+		})
+
+	results, err := Suite.Fs.ReadDir("users/test1/test.txt")
+	Suite.NoError(err)
+	Suite.Len(results, 1)
+
+	Suite.Equal("test.txt", results[0].Name())
+	Suite.Equal(int64(8), results[0].Size())
+	Suite.Equal(apr28, results[0].ModTime())
+	Suite.False(results[0].IsDir())
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
+}
+
+func (Suite *GCSFsSuite) TestReadDir_IsObject_WithCustomTime() {
+	defer gock.Off()
+
+	gock.New(testBaseUrl).
+		Get("/b/bucket1/o/users/test1/test.txt").
+		Reply(200).
+		JSON(map[string]any{
+			"bucket":      "bucket1",
+			"name":        "test.txt",
+			"contentType": "text/plain",
+			"size":        "8",
+			"updated":     apr28.Format(time.RFC3339),
+			"customTime":  jan1.Format(time.RFC3339),
+		})
+
+	results, err := Suite.Fs.ReadDir("users/test1/test.txt")
+	Suite.NoError(err)
+	Suite.Len(results, 1)
+
+	Suite.Equal("test.txt", results[0].Name())
+	Suite.Equal(int64(8), results[0].Size())
+	Suite.Equal(jan1, results[0].ModTime())
+	Suite.False(results[0].IsDir())
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
+}
+
+func (Suite *GCSFsSuite) TestReadDir_IsDir() {
+	defer gock.Off()
+
+	gock.New(testBaseUrl).
+		Get("/b/bucket1/o").
+		AddMatcher(customTimeInFieldsList()).
+		Reply(200).
+		JSON(map[string]any{
+			"kind": "storage#objects",
+			"items": []map[string]any{
+				{
+					"bucket":      "bucket1",
+					"name":        "test.txt",
+					"contentType": "text/plain",
+					"size":        "8",
+					"updated":     apr28.Format(time.RFC3339),
+					//"customTime":  jan1.Format(time.RFC3339),
+				},
+				{
+					"bucket":      "bucket1",
+					"name":        "test2.txt",
+					"contentType": "text/plain",
+					"size":        "16",
+					"updated":     apr28.Format(time.RFC3339),
+					"customTime":  jan1.Format(time.RFC3339),
+				},
+			},
+		})
+
+	results, err := Suite.Fs.ReadDir("users/test1/")
+	Suite.NoError(err)
+	Suite.Len(results, 2)
+
+	Suite.Equal("test.txt", results[0].Name())
+	Suite.Equal(int64(8), results[0].Size())
+	Suite.Equal(apr28, results[0].ModTime())
+	Suite.False(results[0].IsDir())
+
+	Suite.Equal("test2.txt", results[1].Name())
+	Suite.Equal(int64(16), results[1].Size())
+	Suite.Equal(jan1, results[1].ModTime())
+	Suite.False(results[1].IsDir())
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
+}
+
+func (Suite *GCSFsSuite) TestCreate_CustomTimeAttribute() {
+	defer gock.Off()
+
+	Suite.Fs._customTimeOverride = &jan1
+	defer func() { Suite.Fs._customTimeOverride = nil }()
+
+	gock.New(testBaseUrl).
+		Post("/upload/storage/v1/b/bucket1/o").
+		AddMatcher(customTimeInUploadRequest(jan1)).
+		Reply(200)
+
+	_, writer, _, err := Suite.Fs.Create("new.txt", 0)
+	Suite.NoError(err)
+
+	go func() {
+		_, err = writer.Write([]byte("hello world"))
+		Suite.NoError(err)
+		err = writer.Close()
+		Suite.NoError(err)
+	}()
+
+	select {
+	case <-writer.done:
+		break
+	case <-time.After(time.Second * 5):
+		Suite.FailNow("timeout for writer done chan")
+	}
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
+}
+
+func TestGCSFsSuite(t *testing.T) {
+	suite.Run(t, new(GCSFsSuite))
+}
+
+func customTimeInFieldsList() gock.MatchFunc {
+	return func(r *http.Request, _ *gock.Request) (bool, error) {
+		return strings.Contains(r.URL.Query().Get("fields"), "customTime"), nil
+	}
+}
+
+func customTimeInUploadRequest(expectedTime time.Time) gock.MatchFunc {
+	return func(r *http.Request, _ *gock.Request) (bool, error) {
+		buf := &bytes.Buffer{}
+		if _, err := io.Copy(buf, r.Body); err != nil {
+			return false, err
+		}
+		return strings.Contains(
+			buf.String(),
+			fmt.Sprintf("\"customTime\":\"%s\"", expectedTime.Format(time.RFC3339)),
+		), nil
+	}
+}
+
+func printPendingMocks() string {
+	var urls []string
+	for _, mock := range gock.Pending() {
+		urls = append(urls, mock.Request().URLStruct.String())
+	}
+	return strings.Join(urls, ", ")
+}


### PR DESCRIPTION
Changes:
* Set GCS CustomTime attribute on object `Create()`
* Retrieve GCS CustomTime for `Stat()` and `ReadDir()` calls, and overwrite mod time if non-zero
* Allow `ReadDir()` calls on single object
* Upstream fix for unrelated intermittent test failure