### PR TITLE
FPS-115: GCS Empty Dir Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ conf.d/
 .env*
 compose*
 Dockerfile-test*
+
+# misc
+NOTES.md

--- a/vfs/gcsfs.go
+++ b/vfs/gcsfs.go
@@ -106,49 +106,18 @@ func (fs *GCSFs) ConnectionID() string {
 
 // Stat returns a FileInfo describing the named file
 func (fs *GCSFs) Stat(name string) (os.FileInfo, error) {
-	var result *FileInfo
-	var err error
 	if name == "" || name == "." {
 		err := fs.checkIfBucketExists()
 		if err != nil {
-			return result, err
+			return nil, err
 		}
 		return NewFileInfo(name, true, 0, time.Now(), false), nil
 	}
 	if fs.config.KeyPrefix == name+"/" {
 		return NewFileInfo(name, true, 0, time.Now(), false), nil
 	}
-	attrs, err := fs.headObject(name)
-	if err == nil {
-		objSize := attrs.Size
-		objectModTime := customTimeOrDefault(attrs)
-		isDir := attrs.ContentType == dirMimeType || strings.HasSuffix(attrs.Name, "/")
-		return NewFileInfo(name, isDir, objSize, objectModTime, false), nil
-	}
-	if !fs.IsNotExist(err) {
-		return result, err
-	}
-	// now check if this is a prefix (virtual directory)
-	hasContents, err := fs.hasContents(name)
-	if err == nil && hasContents {
-		return NewFileInfo(name, true, 0, time.Now(), false), nil
-	} else if err != nil {
-		return nil, err
-	}
-	// search a dir ending with "/" for backward compatibility
-	return fs.getStatCompat(name)
-}
-
-func (fs *GCSFs) getStatCompat(name string) (os.FileInfo, error) {
-	var result *FileInfo
-	attrs, err := fs.headObject(name + "/")
-	if err != nil {
-		return result, err
-	}
-	objSize := attrs.Size
-	objectModTime := attrs.Updated
-	// NOTE: s3fs.getStatForDir() does NOT override objectModTime, so we won't override here either
-	return NewFileInfo(name, true, objSize, objectModTime, false), nil
+	_, info, err := fs.getObjectStat(name)
+	return info, err
 }
 
 // Lstat returns a FileInfo describing the named file
@@ -236,7 +205,7 @@ func (fs *GCSFs) Rename(source, target string) error {
 	if source == target {
 		return nil
 	}
-	fi, err := fs.Stat(source)
+	realSourceName, fi, err := fs.getObjectStat(source)
 	if err != nil {
 		return err
 	}
@@ -248,8 +217,11 @@ func (fs *GCSFs) Rename(source, target string) error {
 		if hasContents {
 			return fmt.Errorf("Cannot rename non empty directory: %#v", source)
 		}
+		if !strings.HasSuffix(target, "/") {
+			target += "/"
+		}
 	}
-	src := fs.svc.Bucket(fs.config.Bucket).Object(source)
+	src := fs.svc.Bucket(fs.config.Bucket).Object(realSourceName)
 	dst := fs.svc.Bucket(fs.config.Bucket).Object(target)
 	ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(fs.ctxTimeout))
 	defer cancelFn()
@@ -284,17 +256,19 @@ func (fs *GCSFs) Remove(name string, isDir bool) error {
 		if hasContents {
 			return fmt.Errorf("Cannot remove non empty directory: %#v", name)
 		}
+		if !strings.HasSuffix(name, "/") {
+			name += "/"
+		}
 	}
 	ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(fs.ctxTimeout))
 	defer cancelFn()
 
 	err := fs.svc.Bucket(fs.config.Bucket).Object(name).Delete(ctx)
-	metrics.GCSDeleteObjectCompleted(err)
 	if fs.IsNotExist(err) && isDir {
-		name = name + "/"
-		err = fs.svc.Bucket(fs.config.Bucket).Object(name).Delete(ctx)
-		metrics.GCSDeleteObjectCompleted(err)
+		// we can have directories without a trailing "/" (created using v2.1.0 and before)
+		err = fs.svc.Bucket(fs.config.Bucket).Object(strings.TrimSuffix(name, "/")).Delete(ctx)
 	}
+	metrics.GCSDeleteObjectCompleted(err)
 	return err
 }
 
@@ -303,6 +277,9 @@ func (fs *GCSFs) Mkdir(name string) error {
 	_, err := fs.Stat(name)
 	if !fs.IsNotExist(err) {
 		return err
+	}
+	if !strings.HasSuffix(name, "/") {
+		name += "/"
 	}
 	_, w, _, err := fs.Create(name, -1)
 	if err != nil {
@@ -621,6 +598,36 @@ func (fs *GCSFs) resolve(name string, prefix string) (string, bool) {
 		result = strings.TrimSuffix(result, "/")
 	}
 	return result, isDir
+}
+
+// getObjectStat returns the stat result and the real object name as first value
+func (fs *GCSFs) getObjectStat(name string) (string, os.FileInfo, error) {
+	attrs, err := fs.headObject(name)
+	if err == nil {
+		objSize := attrs.Size
+		objectModTime := customTimeOrDefault(attrs)
+		isDir := attrs.ContentType == dirMimeType || strings.HasSuffix(attrs.Name, "/")
+		return name, NewFileInfo(name, isDir, objSize, objectModTime, false), nil
+	}
+	if !fs.IsNotExist(err) {
+		return "", nil, err
+	}
+	// now check if this is a prefix (virtual directory)
+	hasContents, err := fs.hasContents(name)
+	if err != nil {
+		return "", nil, err
+	}
+	if hasContents {
+		return name, NewFileInfo(name, true, 0, time.Now(), false), nil
+	}
+	// finally check if this is an object with a trailing /
+	attrs, err = fs.headObject(name + "/")
+	if err != nil {
+		return "", nil, err
+	}
+	objSize := attrs.Size
+	objectModTime := attrs.Updated
+	return name + "/", NewFileInfo(name, true, objSize, objectModTime, false), nil
 }
 
 func (fs *GCSFs) checkIfBucketExists() error {

--- a/vfs/gcsfs.go
+++ b/vfs/gcsfs.go
@@ -325,9 +325,11 @@ func (*GCSFs) Truncate(name string, size int64) error {
 func (fs *GCSFs) ReadDir(dirname string) ([]os.FileInfo, error) {
 	if !strings.HasSuffix(dirname, `/`) {
 		if attrs, err := fs.headObject(dirname); err == nil {
-			objSize := attrs.Size
-			objectModTime := customTimeOrDefault(attrs)
-			return []os.FileInfo{NewFileInfo(dirname, false, objSize, objectModTime, false)}, nil
+			if !fs.isDirPlaceholderObject(attrs) {
+				objSize := attrs.Size
+				objectModTime := customTimeOrDefault(attrs)
+				return []os.FileInfo{NewFileInfo(dirname, false, objSize, objectModTime, false)}, nil
+			}
 		}
 	}
 
@@ -627,6 +629,7 @@ func (fs *GCSFs) getObjectStat(name string) (string, os.FileInfo, error) {
 	}
 	objSize := attrs.Size
 	objectModTime := attrs.Updated
+	// NOTE: s3fs.getStatForDir() does NOT override objectModTime, so we won't override here either
 	return name + "/", NewFileInfo(name, true, objSize, objectModTime, false), nil
 }
 
@@ -720,6 +723,12 @@ func (fs *GCSFs) Close() error {
 // GetAvailableDiskSize return the available size for the specified path
 func (*GCSFs) GetAvailableDiskSize(dirName string) (*sftp.StatVFS, error) {
 	return nil, ErrStorageSizeUnavailable
+}
+
+func (fs GCSFs) isDirPlaceholderObject(attrs *storage.ObjectAttrs) bool {
+	return attrs.Size == 0 &&
+		attrs.ContentType == dirMimeType &&
+		!strings.HasSuffix(attrs.Name, `/`)
 }
 
 func customTimeOrDefault(attrs *storage.ObjectAttrs) time.Time {

--- a/vfs/gcsfs_test.go
+++ b/vfs/gcsfs_test.go
@@ -253,6 +253,8 @@ func (Suite *GCSFsSuite) TestReadDir_NoTrailingSlash_GoodEmptyDir() {
 	results, err := Suite.Fs.ReadDir(prefix)
 	Suite.NoError(err)
 	Suite.Empty(results)
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
 }
 
 func (Suite *GCSFsSuite) TestReadDir_WithTrailingSlash_GoodEmptyDir() {
@@ -280,6 +282,8 @@ func (Suite *GCSFsSuite) TestReadDir_WithTrailingSlash_GoodEmptyDir() {
 	results, err := Suite.Fs.ReadDir(prefix)
 	Suite.NoError(err)
 	Suite.Empty(results)
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
 }
 
 func (Suite *GCSFsSuite) TestReadDir_NoTrailingSlash_BadEmptyDir() {
@@ -288,7 +292,7 @@ func (Suite *GCSFsSuite) TestReadDir_NoTrailingSlash_BadEmptyDir() {
 
 	gock.New(testBaseURL).
 		Get("/b/bucket1/o").
-		MatchParam("prefix", prefix).
+		MatchParam("prefix", prefix+"/").
 		MatchParam("delimiter", "/").
 		AddMatcher(customTimeInFieldsList()).
 		Reply(200).
@@ -312,6 +316,8 @@ func (Suite *GCSFsSuite) TestReadDir_NoTrailingSlash_BadEmptyDir() {
 	Suite.Equal("bad-empty", results[0].Name())
 	Suite.Equal(int64(0), results[0].Size())
 	Suite.True(results[0].IsDir())
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
 }
 
 func (Suite *GCSFsSuite) TestReadDir_WithTrailingSlash_BadEmptyDir() {
@@ -329,6 +335,8 @@ func (Suite *GCSFsSuite) TestReadDir_WithTrailingSlash_BadEmptyDir() {
 	results, err := Suite.Fs.ReadDir(prefix)
 	Suite.NoError(err)
 	Suite.Empty(results)
+
+	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
 }
 
 func (Suite *GCSFsSuite) TestIsDirPlaceholderObject() {

--- a/vfs/gcsfs_test.go
+++ b/vfs/gcsfs_test.go
@@ -306,8 +306,9 @@ func (Suite *GCSFsSuite) TestReadDir_NoTrailingSlash_BadEmptyDir() {
 
 	results, err := Suite.Fs.ReadDir(prefix)
 	Suite.NoError(err)
-	Suite.Len(results, 1) // TODO: this is different behavior than `TestReadDir_NoTrailingSlash_GoodEmptyDir`
+	Suite.Len(results, 1)
 
+	// NOTE: this listing MUST be present for FileZilla to display empty "bad" dirs with no trailing `/` in prefix
 	Suite.Equal("bad-empty", results[0].Name())
 	Suite.Equal(int64(0), results[0].Size())
 	Suite.True(results[0].IsDir())
@@ -327,7 +328,7 @@ func (Suite *GCSFsSuite) TestReadDir_WithTrailingSlash_BadEmptyDir() {
 
 	results, err := Suite.Fs.ReadDir(prefix)
 	Suite.NoError(err)
-	Suite.Len(results, 0)
+	Suite.Empty(results)
 }
 
 func (Suite *GCSFsSuite) TestIsDirPlaceholderObject() {

--- a/vfs/gcsfs_test.go
+++ b/vfs/gcsfs_test.go
@@ -228,6 +228,125 @@ func (Suite *GCSFsSuite) TestReadDir_IsDir() {
 	Suite.True(gock.IsDone(), "pending mocks: %s", printPendingMocks())
 }
 
+func (Suite *GCSFsSuite) TestReadDir_NoTrailingSlash_GoodEmptyDir() {
+	defer gock.Off()
+	prefix := "users/test1/good-empty"
+
+	gock.New(testBaseURL).
+		Get("/b/bucket1/o").
+		MatchParam("prefix", prefix).
+		MatchParam("delimiter", "/").
+		AddMatcher(customTimeInFieldsList()).
+		Reply(200).
+		JSON(map[string]any{
+			"items": []map[string]any{
+				{
+					"name":        "users/test1/good-empty/",
+					"contentType": "inode/directory",
+					"size":        "0",
+					"updated":     "2026-03-23T20:53:57.499Z",
+					"customTime":  "2026-03-23T20:53:57Z",
+				},
+			},
+		})
+
+	results, err := Suite.Fs.ReadDir(prefix)
+	Suite.NoError(err)
+	Suite.Empty(results)
+}
+
+func (Suite *GCSFsSuite) TestReadDir_WithTrailingSlash_GoodEmptyDir() {
+	defer gock.Off()
+	prefix := "users/test1/good-empty/"
+
+	gock.New(testBaseURL).
+		Get("/b/bucket1/o").
+		MatchParam("prefix", prefix).
+		MatchParam("delimiter", "/").
+		AddMatcher(customTimeInFieldsList()).
+		Reply(200).
+		JSON(map[string]any{
+			"items": []map[string]any{
+				{
+					"name":        "users/test1/good-empty/",
+					"contentType": "inode/directory",
+					"size":        "0",
+					"updated":     "2026-03-23T20:53:57.499Z",
+					"customTime":  "2026-03-23T20:53:57Z",
+				},
+			},
+		})
+
+	results, err := Suite.Fs.ReadDir(prefix)
+	Suite.NoError(err)
+	Suite.Empty(results)
+}
+
+func (Suite *GCSFsSuite) TestReadDir_NoTrailingSlash_BadEmptyDir() {
+	defer gock.Off()
+	prefix := "users/test1/bad-empty"
+
+	gock.New(testBaseURL).
+		Get("/b/bucket1/o").
+		MatchParam("prefix", prefix).
+		MatchParam("delimiter", "/").
+		AddMatcher(customTimeInFieldsList()).
+		Reply(200).
+		JSON(map[string]any{
+			"items": []map[string]any{
+				{
+					"name":        "users/test1/bad-empty",
+					"contentType": "inode/directory",
+					"size":        "0",
+					"updated":     "2026-03-23T20:53:57.499Z",
+					"customTime":  "2026-03-23T20:53:57Z",
+				},
+			},
+		})
+
+	results, err := Suite.Fs.ReadDir(prefix)
+	Suite.NoError(err)
+	Suite.Len(results, 1) // TODO: this is different behavior than `TestReadDir_NoTrailingSlash_GoodEmptyDir`
+
+	Suite.Equal("bad-empty", results[0].Name())
+	Suite.Equal(int64(0), results[0].Size())
+	Suite.True(results[0].IsDir())
+}
+
+func (Suite *GCSFsSuite) TestReadDir_WithTrailingSlash_BadEmptyDir() {
+	defer gock.Off()
+	prefix := "users/test1/bad-empty/"
+
+	gock.New(testBaseURL).
+		Get("/b/bucket1/o").
+		MatchParam("prefix", prefix).
+		MatchParam("delimiter", "/").
+		AddMatcher(customTimeInFieldsList()).
+		Reply(200).
+		JSON(`{}`)
+
+	results, err := Suite.Fs.ReadDir(prefix)
+	Suite.NoError(err)
+	Suite.Len(results, 0)
+}
+
+func (Suite *GCSFsSuite) TestIsDirPlaceholderObject() {
+	for _, tt := range []struct {
+		name        string
+		size        int64
+		contentType string
+		expected    bool
+	}{
+		{name: "users/test1/dir", size: 0, contentType: "inode/directory", expected: true},
+		{name: "users/test1/dir", size: 0, contentType: "text/plain", expected: false},
+		{name: "users/test1/dir", size: 999, contentType: "inode/directory", expected: false},
+		{name: "users/test1/dir/", size: 0, contentType: "inode/directory", expected: false},
+	} {
+		attrs := &storage.ObjectAttrs{Name: tt.name, ContentType: tt.contentType, Size: tt.size}
+		Suite.Equal(tt.expected, Suite.Fs.isDirPlaceholderObject(attrs))
+	}
+}
+
 func (Suite *GCSFsSuite) TestCreate_CustomTimeAttribute() {
 	Suite.Fs.nowFunc = func() time.Time { return jan1 }
 	defer func() {


### PR DESCRIPTION
Changes:
* Force trailing "/" for GCS virtual directories / folder prefixes 
(cherry picked from commit [`93dfb03`](https://github.com/drakkan/sftpgo/commit/93dfb03eafdd024b7237e9f225b01ac22a1d5532))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core GCS VFS path semantics (stat/rename/remove/mkdir/readdir), so regressions could impact directory operations and client compatibility, though changes are localized and covered by new tests.
> 
> **Overview**
> Fixes GCS virtual directory edge cases by **consistently normalizing directory object names with a trailing `/`** across `Mkdir`, `Remove`, and `Rename`, while still supporting legacy directory placeholders created without the slash.
> 
> Refactors `Stat` to use a new `getObjectStat` helper that returns both `FileInfo` and the *real* object key (handling the trailing-`/` compat lookup), and updates `ReadDir` to ignore “good” empty directory placeholder objects while still listing “bad” empty dirs needed for some clients (e.g., FileZilla). Adds targeted unit tests covering these empty-dir listing scenarios and placeholder detection. Also updates `.gitignore` to ignore `NOTES.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 398afeb390f8ea0723f2b3b2b90bc53eda4443b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->